### PR TITLE
closes drawer on item clicked

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,6 +5,7 @@ import Home from '../Home/Home';
 import Upload from '../Upload/Upload';
 import Player from '../Player/Player';
 import { CookiesProvider } from 'react-cookie';
+import Nav from '../Navbar/Nav';
 
 import UserContextProvider from '../../contexts/userContext';
 
@@ -17,6 +18,7 @@ const App = () => {
         <BrowserRouter>
           <Switch>
             <UserContextProvider>
+              <Nav />
               <Route exact path="/" component={Home} />
               <Route path="/SignUp" component={SignUp} />
               <Route path="/SignIn" component={SignIn} />

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import Nav from '../Navbar/Nav';
 import SubHome from './SubHome';
 
 const Home = () => {
   return (
     <div>
-      <Nav />
       <SubHome />
     </div>
   );

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -32,7 +32,7 @@ const MenuDrawer = (props) => {
           onClose={props.fClose}>
           <div className={clsx(classes.list)} role="presentation">
             <List>
-              <ListItem button component={Link} to="/">
+              <ListItem button component={Link} to="/" onClick={props.fClose}>
                 <ListItemIcon>
                   <InboxIcon /> Home
                 </ListItemIcon>
@@ -41,7 +41,7 @@ const MenuDrawer = (props) => {
             </List>
             <Divider />
             <List>
-              <ListItem button component={Link} to="/Upload">
+              <ListItem button component={Link} to="/Upload" onClick={props.fClose}>
                 <ListItemIcon>
                   <MailIcon /> Upload
                 </ListItemIcon>

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -97,7 +97,7 @@ const NavBar = () => {
   };
 
   const toggleDrawer1 = () => {
-    setOpen(false);
+    return setOpen(false);
   };
 
   //const handleProfileMenuOpen = (event) => {


### PR DESCRIPTION
Before this PR,clicking on any link on the drawer didnot close the drawer.To close it,user was forced to add an extra step of clicking away from the drawer.This is a problem to mobile users especially if the drawer covers all the mobile screen,mobile users will have no space to click inorder to close the drawer.
This PR does the job for the user, closes the drawer when user clicks on any item.
# Before
## Desktop View
![Untitled_ Sep 22, 2020 7_58 PM](https://user-images.githubusercontent.com/64994841/93926005-e0bbe080-fd0e-11ea-8994-4af79842de0d.gif)
## Mobile View(extra small screens)
![LanTube](https://user-images.githubusercontent.com/64994841/93927677-1eba0400-fd11-11ea-8500-a3b8eec8f6b5.gif)



# After

## Desktop View

![Untitled_ Sep 22, 2020 8_01 PM](https://user-images.githubusercontent.com/64994841/93932913-ca1a8700-fd18-11ea-82e9-76ec7c19a278.gif)


## Mobile View


![lantube](https://user-images.githubusercontent.com/64994841/93932758-93dd0780-fd18-11ea-8dfa-90e6eaf8588c.gif)

@FotieMConstant @TatchumNono @marcosriani could you give a thought on this